### PR TITLE
Bring in the high-vis pollution option from mainline amplio2

### DIFF
--- a/aviation.tilespec
+++ b/aviation.tilespec
@@ -307,3 +307,8 @@ styles =
       "ts.horses",     "Single1"
       "ts.seals",      "Single1"
     }
+
+[option_highvis_pollution]
+name = "highvis_pollution"
+description = _("Highly-visible Pollution")
+default = FALSE


### PR DESCRIPTION
In Freeciv21 3.1, an option for high-visibility pollution was added to amplio2. This is imported through amplio2/terrain1.spec. Freeciv21 fails to load if an unknown option is present in the spec files.

This declares the option so the tileset loads properly.